### PR TITLE
Add ISBN10 generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Provide check digit algorithms and calculators written by Go.
 ### Calculators
 
 - [ISBN-10](https://en.wikipedia.org/wiki/International_Standard_Book_Number)
-  - Only Verify
 - [ISBN-13](https://en.wikipedia.org/wiki/International_Standard_Book_Number)
 - [EAN-8](https://en.wikipedia.org/wiki/EAN-8)
 - [EAN-13](https://en.wikipedia.org/wiki/EAN-13)

--- a/checkdigit.go
+++ b/checkdigit.go
@@ -78,7 +78,7 @@ func NewVerhoeff() Provider {
 }
 
 // NewISBN10 returns new Verifier that implemented modulus 11 weight 10 to 2 calculator.
-func NewISBN10() Verifier {
+func NewISBN10() Provider {
 	return &isbn10{}
 
 }

--- a/checkdigit.go
+++ b/checkdigit.go
@@ -77,10 +77,9 @@ func NewVerhoeff() Provider {
 	}
 }
 
-// NewISBN10 returns new Verifier that implemented modulus 11 weight 10 to 2 calculator.
+// NewISBN10 returns new Provider that implemented modulus 11 weight 10 to 2 calculator.
 func NewISBN10() Provider {
 	return &isbn10{}
-
 }
 
 // NewISBN13 returns new Provider that implemented modulus 10 weight 3 calculator.

--- a/checkdigit_test.go
+++ b/checkdigit_test.go
@@ -158,14 +158,24 @@ func ExampleNewVerhoeff() {
 
 func ExampleNewISBN10() {
 
-	v := checkdigit.NewISBN10()
+	p := checkdigit.NewISBN10()
 
-	code := "155860832X"
-	ok := v.Verify(code)
-	fmt.Printf("code: %s, verify: %t\n", code, ok)
+	seed := "155860832"
+	cd, err := p.Generate(seed)
+	if err != nil {
+		log.Fatalln("failed to generate check digit")
+	}
+
+	digit := "X"
+	if cd != 10 {
+		digit = strconv.Itoa(cd)
+	}
+
+	ok := p.Verify(seed + digit)
+	fmt.Printf("seed: %s, check digit: %s, verify: %t\n", seed, digit, ok)
 
 	// Output:
-	// code: 155860832X, verify: true
+	// seed: 155860832, check digit: X, verify: true
 }
 
 func ExampleNewISBN13() {

--- a/isbn.go
+++ b/isbn.go
@@ -32,6 +32,28 @@ func (i10 *isbn10) Verify(code string) bool {
 	return sum%11 == 0
 }
 
+// Generate implements checkdigit.Generator interface.
+func (i10 *isbn10) Generate(seed string) (int, error) {
+
+	if len(seed) != 9 {
+		return 0, ErrInvalidArgument
+	}
+
+	sum, multiply := 0, 10
+
+	for _, n := range seed {
+
+		if isNotNumber(n) {
+			return 0, ErrInvalidArgument
+		}
+
+		sum += multiply * int(n-'0')
+		multiply--
+	}
+
+	return 11 - sum%11, nil
+}
+
 // Verify implements checkdigit.Verifier interface.
 func (i13 *isbn13) Verify(code string) bool {
 

--- a/isbn.go
+++ b/isbn.go
@@ -33,6 +33,7 @@ func (i10 *isbn10) Verify(code string) bool {
 }
 
 // Generate implements checkdigit.Generator interface.
+// This will return a "10" instead of an "X", since the interface expects an int.
 func (i10 *isbn10) Generate(seed string) (int, error) {
 
 	if len(seed) != 9 {

--- a/isbn_test.go
+++ b/isbn_test.go
@@ -52,6 +52,59 @@ func TestIsbn10_Verify(t *testing.T) {
 	}
 }
 
+func TestIsbn10_Generate(t *testing.T) {
+	cases := map[string]struct {
+		in      string
+		out     int
+		isError bool
+	}{
+		"Regular 1": {
+			in:  "002651562",
+			out: 8,
+		},
+		"Regular 2": {
+			in:  "007231592",
+			out: 10,
+		},
+		"Regular 3": {
+			in:  "155860832",
+			out: 10,
+		},
+		"Irregular 1": {
+			isError: true,
+		},
+		"Irregular 2": {
+			in:      "9780002715096",
+			isError: true,
+		},
+		"Irregular 3": {
+			in:      "15586",
+			isError: true,
+		},
+		"Irregular 4": {
+			in:      "155860832X",
+			isError: true,
+		},
+		"Irregular 5": {
+			in:      "aaaaaaaaa",
+			isError: true,
+		},
+	}
+
+	for name, c := range cases {
+		c := c
+		t.Run(name, func(t *testing.T) {
+			r, err := checkdigit.NewISBN10().Generate(c.in)
+			if c.isError && err == nil {
+				t.Error("unexpected error")
+			}
+			if c.out != r {
+				t.Errorf("not equal, expected = %d, given = %d", c.out, r)
+			}
+		})
+	}
+}
+
 func TestIsbn13_Verify(t *testing.T) {
 
 	cases := map[string]struct {


### PR DESCRIPTION
10 as a digit is a bit weird, but since the `Generate` interface was forced to `(int, error)` I had no other choice.

Changing the interface would probably be rejected as well.
10 to X conversion has to be done when concatenating the seed with the check digit.